### PR TITLE
Nodejs 12.x Update

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -23,6 +23,7 @@ Parameters:
   StringMatching:
     Type: String
     Description: '(Optional) String to search in the response body. If found the healcheck will succeed.'
+    Description: '(Optional) String to search in the response body. If found the healthcheck will succeed.'
   InvertHealtcheckStatus:
     Type: String
     Default: false

--- a/template.yml
+++ b/template.yml
@@ -54,7 +54,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Description: >-
         Perform healthchecks on private IP or private FQDN (Private Route53). 
         Healthchecks status are pushed to Cloudwatch custom metrics.

--- a/template.yml
+++ b/template.yml
@@ -22,6 +22,7 @@ Parameters:
     Description: 'Path of the URL to test. Default: no path'
   StringMatching:
     Type: String
+    Default: ''
     Description: '(Optional) String to search in the response body. If found the healthcheck will succeed.'
   InvertHealtcheckStatus:
     Type: String

--- a/template.yml
+++ b/template.yml
@@ -22,7 +22,6 @@ Parameters:
     Description: 'Path of the URL to test. Default: no path'
   StringMatching:
     Type: String
-    Description: '(Optional) String to search in the response body. If found the healcheck will succeed.'
     Description: '(Optional) String to search in the response body. If found the healthcheck will succeed.'
   InvertHealtcheckStatus:
     Type: String


### PR DESCRIPTION
AWS does not allow creation of new Lambda functions using the Nodejs 8.10 runtime.
Please merge this PR to update the runtime to 12.x.
I also fixed a typo and explicitly set the default StringMatching to '' as leaving it blank gives an error when deploying the current template. 